### PR TITLE
fix: image tag changed acc. to service-b: demoservice-b:v

### DIFF
--- a/day-4/kubernetes-manifest/deployment-svc-b.yml
+++ b/day-4/kubernetes-manifest/deployment-svc-b.yml
@@ -16,7 +16,7 @@ spec:
         app: service-b-deployment
     spec:
       containers:
-      - image: abhishekf5/demoservice-a:v
+      - image: abhishekf5/demoservice-b:v
         name: service-b
         imagePullPolicy: Always
         ports:


### PR DESCRIPTION
The /call-service-b API was failing with ECONNREFUSED because the service-b Deployment was using the incorrect service-a image tag. Updated the image tag to the correct service-b version, resolving the connection refusal and allowing traffic to reach the intended Pod.