### PR TITLE
fix: set default Grafana admin password and document secret recovery

### DIFF
--- a/day-2/custom_kube_prometheus_stack.yml
+++ b/day-2/custom_kube_prometheus_stack.yml
@@ -1,3 +1,6 @@
+grafana:
+  adminPassword: prom-operator
+
 alertmanager:
   alertmanagerSpec:
     # Selects Alertmanager configuration based on these labels. Ensure that the Alertmanager configuration has matching labels.

--- a/day-2/readme.md
+++ b/day-2/readme.md
@@ -127,10 +127,29 @@ kubectl port-forward service/prometheus-operated -n monitoring 9090:9090
 
 **NOTE:** If you are using an EC2 Instance or Cloud VM, you need to pass `--address 0.0.0.0` to the above command. Then you can access the UI on <instance-ip:port>
 
-- **Grafana UI**: password is `prom-operator`
-```bash
-kubectl port-forward service/monitoring-grafana -n monitoring 8080:80
-```
+- **Grafana UI**:
+  - **Default Credentials**:
+    - **Username**: `admin`
+    - **Password**: `prom-operator` (explicitly configured in `custom_kube_prometheus_stack.yml`)
+
+
+  **Retrieving Auto-Generated/Actual Credentials:**
+  If you did not use the custom configuration file, or if the credentials don't work, retrieve them directly from the Kubernetes secret:
+  
+  *Get username:*
+  ```bash
+  kubectl get secret --namespace monitoring monitoring-grafana -o jsonpath='{.data.admin-user}' | base64 -d
+  ```
+  
+  *Get password:*
+  ```bash
+  kubectl get secret --namespace monitoring monitoring-grafana -o jsonpath='{.data.admin-password}' | base64 -d
+  ```
+
+  **Port-forwarding to access Grafana UI:**
+  ```bash
+  kubectl port-forward service/monitoring-grafana -n monitoring 8080:80
+  ```
 - **Alertmanager UI**:
 ```bash
 kubectl port-forward service/alertmanager-operated -n monitoring 9093:9093

--- a/day-4/application/service-a/metrics_instrumentation_analysis.md
+++ b/day-4/application/service-a/metrics_instrumentation_analysis.md
@@ -1,0 +1,181 @@
+# In-Depth Metrics & Instrumentation Analysis: Service A
+
+This document provides a detailed, technical analysis of `service-a`. It explains how metrics, tracing, and logging are implemented, detailing the logic, libraries, and middleware patterns used.
+
+---
+
+## 🗺️ Project Architecture Overview
+
+`service-a` is a Node.js web application built with the **Express** framework. It serves as an entry point for user requests, handles basic routing, generates logs, interacts with downstream services (like `service-b`), and is fully instrumented for observability:
+- **Metrics collection & exposure** via `prom-client` (Prometheus format).
+- **Distributed tracing** via **OpenTelemetry SDK** (exported to Jaeger).
+- **Structured logging** via `pino`.
+
+---
+
+## 📦 Key Dependencies
+
+The primary observability dependencies are:
+
+| Package | Purpose |
+| :--- | :--- |
+| `prom-client` | Standard Prometheus client library to define, register, and serve metrics. |
+| `@opentelemetry/sdk-node` | OpenTelemetry Node.js SDK to bootstrap tracing. |
+| `@opentelemetry/exporter-jaeger` | Exporter to ship spans directly to Jaeger collector. |
+| `@opentelemetry/instrumentation-express` / `http` | Automatic hook interception to trace Express routes and HTTP requests. |
+| `pino` | High-performance JSON-based logger. |
+
+---
+
+## 📈 Metrics Instrumentation Implementation
+
+The metrics instrumentation is implemented using `prom-client` inside [index.js]. Three primary Prometheus metric types are utilized: **Counter**, **Histogram**, **Summary**, and **Gauge**.
+
+### 1. Defined Metric Types & Declarations
+
+#### A. Request Counter (`http_requests_total`)
+Tracks the cumulative count of requests incoming to the server.
+```javascript
+const httpRequestCounter = new promClient.Counter({
+    name: 'http_requests_total',
+    help: 'Total number of HTTP requests',
+    labelNames: ['method', 'path', 'status_code'],
+});
+```
+*   **Dimensions (Labels):** `method` (GET/POST), `path` (endpoint URL), and `status_code` (e.g., 200, 404, 500). This allows slicing and dicing the error rates and endpoint traffic.
+
+#### B. Request Duration Histogram (`http_request_duration_seconds`)
+Measures the distribution of request durations using pre-configured latency buckets.
+```javascript
+const requestDurationHistogram = new promClient.Histogram({
+    name: 'http_request_duration_seconds',
+    help: 'Duration of HTTP requests in seconds',
+    labelNames: ['method', 'path', 'status_code'],
+    buckets: [0.1, 0.5, 1, 5, 10], // Buckets in seconds
+});
+```
+*   **Buckets:** Count boundaries at $100\text{ms}$, $500\text{ms}$, $1\text{s}$, $5\text{s}$, and $10\text{s}$. Useful for computing quantiles (like p95/p99) on the Prometheus server using `histogram_quantile`.
+
+#### C. Request Duration Summary (`http_request_duration_summary_seconds`)
+Calculates streaming quantiles directly on the client side.
+```javascript
+const requestDurationSummary = new promClient.Summary({
+    name: 'http_request_duration_summary_seconds',
+    help: 'Summary of the duration of HTTP requests in seconds',
+    labelNames: ['method', 'path', 'status_code'],
+    percentiles: [0.5, 0.9, 0.99],
+});
+```
+*   **Percentiles:** Configured to calculate the 50th (median), 90th, and 99th percentiles in-memory.
+
+#### D. Active Task Gauge (`node_gauge_example`)
+Tracks a value that can go up and down (in this case, measuring execution times of async tasks).
+```javascript
+const gauge = new promClient.Gauge({
+    name: 'node_gauge_example',
+    help: 'Example of a gauge tracking async task duration',
+    labelNames: ['method', 'status']
+});
+```
+
+---
+
+## ⚙️ Metrics Collection & Scraping Logic
+
+### 1. Global Request Tracking Middleware
+To record request metrics automatically without manual instrumentation in every route, a custom Express middleware is applied globally (lines 66-77):
+
+```javascript
+app.use((req, res, next) => {
+    const start = Date.now();
+    res.on('finish', () => {
+        const duration = (Date.now() - start) / 1000; // Convert ms to seconds
+        const { method, url } = req;
+        const statusCode = res.statusCode;
+        
+        // Record Counter, Histogram, and Summary
+        httpRequestCounter.labels({ method, path: url, status_code: statusCode }).inc();
+        requestDurationHistogram.labels({ method, path: url, status_code: statusCode }).observe(duration);
+        requestDurationSummary.labels({ method, path: url, status_code: statusCode }).observe(duration);
+    });
+    next();
+});
+```
+
+#### Middleware Lifecycle Logic:
+1.  **Start Timestamp:** Captured at the entry of the request via `Date.now()`.
+2.  **`res.on('finish')` Hook:** Express processes the routes asynchronously. Listening to the `finish` event ensures that the metrics are logged **only after** the response has been completely written and flushed to the network. This guarantees:
+    *   The correct HTTP status code (`res.statusCode`) is captured.
+    *   The total duration includes the time taken by the controller and route handlers.
+3.  **Observation Recording:**
+    *   `.inc()` increments the counter by 1.
+    *   `.observe(duration)` records the execution time into both the Histogram and Summary buckets.
+
+### 2. Manual Timer Tracking (Gauge)
+For specific long-running or asynchronous operations (like the `/example` route), a timer-based gauge is used:
+```javascript
+app.get('/example', async (req, res) => {
+    const endGauge = gauge.startTimer({ method: req.method, status: res.statusCode });
+    await simulateAsyncTask(); // Simulates a 0-5 second delay
+    endGauge(); // Stops the timer and records the duration
+    res.send('Async task completed');
+});
+```
+*   `gauge.startTimer()` initiates a clock.
+*   Calling the returned `endGauge()` function stops the timer and automatically updates the gauge with the elapsed duration.
+
+### 3. Exposing the Scrape Endpoint
+Prometheus collects metrics by periodically pulling (scraping) an HTTP endpoint. This is exposed at `/metrics`:
+```javascript
+app.get('/metrics', async (req, res) => {
+    res.set('Content-Type', promClient.register.contentType);
+    res.end(await promClient.register.metrics());
+});
+```
+*   Sets the Content-Type header to `text/plain; version=0.0.4` (standard Prometheus format).
+*   Retrieves all registered metrics serialized into the Prometheus text format via `promClient.register.metrics()`.
+
+---
+
+## 🔍 Tracing Instrumentation (OpenTelemetry)
+
+Distributed tracing tracks the request flow across service boundaries. Tracing in `service-a` is orchestrated via [tracing.js].
+
+### 1. Initialization Order (CRITICAL)
+In `index.js`, the very first import block is:
+```javascript
+require('dotenv').config();
+require('./tracing'); // Initialize tracing immediately!
+```
+> [!IMPORTANT]
+> OpenTelemetry depends on **monkey-patching** core Node.js modules (`http`, `https`) and third-party modules (like `express` and `axios`). Therefore, `tracing.js` **must** run before any package imports (like `express` or `axios`) occur. If imported later, auto-instrumentation will fail to intercept outgoing/incoming requests.
+
+### 3. Tracing Setup Details
+*   **Tracer Provider:** `NodeTracerProvider` bootstraps tracing, configured with a service name resource attribute of `service-a`.
+*   **Exporter:** Spans are collected using a `JaegerExporter` pointing to the collector endpoint defined by `process.env.OTEL_EXPORTER_JAEGER_ENDPOINT`.
+*   **Span Processor:** A `SimpleSpanProcessor` passes spans to the exporter immediately as they end (ideal for development/testing).
+*   **Auto-instrumentation:**
+    ```javascript
+    registerInstrumentations({
+      instrumentations: [
+        new HttpInstrumentation({
+          applyCustomAttributesOnSpan: (span, request, response) => {
+            span.setAttribute('custom-attribute', 'custom-value');
+          },
+        }),
+        new ExpressInstrumentation(),
+      ],
+    });
+    ```
+    *   `HttpInstrumentation` traces outgoing HTTP calls (like `axios.get` calls to `service-b`) and incoming HTTP traffic.
+    *   `ExpressInstrumentation` tracks Express routes and middleware execution times as sub-spans.
+
+---
+
+## 🚦 Endpoints & Testing Logic
+
+1.  **`/` and `/healthy` (200 OK):** Used to test basic success flows.
+2.  **`/serverError` (500 Internal Server Error) & `/notFound` (404 Not Found):** Verifies that the metrics middleware successfully logs non-200 HTTP statuses.
+3.  **`/logs`:** Invokes custom logger statements to test integration with log collection backends.
+4.  **`/crash`:** Exits the process (`process.exit(1)`), which tests container restart policies and system resilience.
+5.  **`/call-service-b`:** Traces a multi-tier downstream call. When `axios` calls `service-b`, OpenTelemetry injects trace context headers (`traceparent`) into the HTTP header, which `service-b`'s tracing library reads, correlating the logs and traces between both microservices.

--- a/day-4/application/service-b/metrics_instrumentation_analysis.md
+++ b/day-4/application/service-b/metrics_instrumentation_analysis.md
@@ -1,0 +1,95 @@
+# In-Depth Metrics & Instrumentation Analysis: Service B
+
+This document provides a detailed, technical analysis of `service-b`. It explains the current instrumentation status, logic flow, and its integration in the distributed tracing architecture.
+
+---
+
+## 🗺️ Project Architecture Overview
+
+`service-b` is a lightweight Node.js web application built with the **Express** framework. It serves as a downstream dependency for `service-a`.
+- **Primary Endpoint:** Exposes a simple `GET /hello` route returning the string `"Hello from Service B!"`.
+- **Port:** Runs on port `3002`.
+- **Observability Profile:** Unlike `service-a`, `service-b` focuses primarily on **Distributed Tracing** to participate in the request lifecycle initiated by upstream callers.
+
+---
+
+## 📦 Key Dependencies
+
+The dependencies match `service-a`:
+
+| Package | Purpose |
+| :--- | :--- |
+| `@opentelemetry/sdk-node` | OpenTelemetry Node.js SDK to bootstrap tracing. |
+| `@opentelemetry/exporter-jaeger` | Exporter to ship spans to the Jaeger collector. |
+| `@opentelemetry/instrumentation-express` / `http` | Automatic hook interception to trace Express routes and incoming HTTP requests. |
+| `morgan` | Standard HTTP request logger middleware. |
+| `prom-client` | Declared in `package.json`, but currently **unused** in the application code. |
+
+---
+
+## 📈 Metrics Instrumentation Status
+
+> [!WARNING]
+> **No Custom Metrics Configured in Code**
+>
+> Although `prom-client` is defined in `package.json`, [index.js] does not import or implement any metric tracking (no counter, histogram, gauge, or `/metrics` endpoint). 
+
+If metrics collection is needed for `service-b` in the future, it should follow the same Express middleware pattern implemented in `service-a` to expose a `/metrics` scrape endpoint.
+
+---
+
+## 🔍 Tracing Instrumentation (OpenTelemetry)
+
+`service-b` uses OpenTelemetry for distributed tracing. Tracing is initialized via [tracing.js].
+
+### 1. Initialization Order
+Just like `service-a`, tracing must be initialized at the very entry point of the process before any other modules:
+```javascript
+require('dotenv').config();
+require('./tracing'); // Must load first to patch http and express
+const express = require('express');
+```
+
+### 2. Tracing Configuration
+*   **Service Name:** Configured specifically as `service-b` to distinguish its trace spans from `service-a` in Jaeger.
+    ```javascript
+    [SemanticResourceAttributes.SERVICE_NAME]: 'service-b'
+    ```
+*   **Exporter:** Spans are pushed to the collector at the URL specified by `process.env.OTEL_EXPORTER_JAEGER_ENDPOINT`.
+*   **Span Processor:** Uses a `SimpleSpanProcessor` to send tracing data synchronously to Jaeger.
+*   **Auto-instrumentation:** Automatically intercepts incoming `http` calls and routes them through the `ExpressInstrumentation` middleware to capture execution time as spans.
+
+---
+
+## 🔄 Distributed Trace Context Propagation
+
+The primary role of `service-b` is to serve downstream requests from `service-a`. Distributed tracing allows these requests to be correlated across network boundaries.
+
+Here is how the trace context propagates between the two services:
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant Client
+    participant ServiceA as Service A (Port 3001)
+    participant ServiceB as Service B (Port 3002)
+    participant Jaeger as Jaeger Collector
+
+    Client->>ServiceA: GET /call-service-b
+    Note over ServiceA: HttpInstrumentation starts Root Span
+    ServiceA->>ServiceB: GET /hello (with traceparent header)
+    Note over ServiceB: HttpInstrumentation extracts traceparent
+    Note over ServiceB: Starts Child Span under Root Span
+    ServiceB-->>ServiceA: "Hello from Service B!"
+    Note over ServiceB: Finishes Child Span & sends to Jaeger
+    ServiceB->>Jaeger: Send Span (Service B)
+    ServiceA-->>Client: HTML Response
+    Note over ServiceA: Finishes Root Span & sends to Jaeger
+    ServiceA->>Jaeger: Send Span (Service A)
+```
+
+### Context Propagation Process:
+1.  **Trace Headers Injection:** When `service-a` makes an outgoing HTTP request to `service-b` using `axios`, OpenTelemetry's `HttpInstrumentation` in `service-a` intercepts the call and injects a standard W3C trace context header (e.g. `traceparent: 00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01`) into the request headers.
+2.  **Trace Headers Extraction:** When `service-b` receives the HTTP request at `GET /hello`, its own `HttpInstrumentation` intercepts the request and extracts the `traceparent` header.
+3.  **Parent-Child Linking:** Rather than starting a new trace, `service-b` reads the trace ID (`4bf92...`) and parent span ID (`00f06...`) and creates a **child span** under that trace.
+4.  **Correlation in Jaeger:** Both services ship their spans to Jaeger. Jaeger joins these spans using the common Trace ID, rendering a single end-to-end timeline chart of the request showing how much time was spent in `service-a` versus `service-b`.


### PR DESCRIPTION
## Summary

Fixes Grafana login failures caused by newer `kube-prometheus-stack` releases generating a random admin password by default.

Fixes- #62 

### Changes

* Explicitly sets `grafana.adminPassword: prom-operator` in `custom_kube_prometheus_stack.yml`.
* Adds documentation for retrieving the auto-generated password from existing installations where the secret has already been created.

### Result

Fresh installations use a predictable admin password, while existing users have clear upgrade and recovery instructions.
